### PR TITLE
Fix the release steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ We use the stove gem to release the cookbook:
 ```bash
 bundle install
 bundle exec stove login --username login --key ~/.chef/key.pem
-bundle exec stove --log-level debug
+bundle exec stove --log-level debug --branch main
 ```
 
 ## Author


### PR DESCRIPTION
Stove defaults to master

Signed-off-by: Tim Smith <tsmith84@gmail.com>