### PR TITLE
🐛 update stove pipeline

### DIFF
--- a/.github/workflows/release-supermarket.yml
+++ b/.github/workflows/release-supermarket.yml
@@ -13,9 +13,12 @@ jobs:
       - uses: ruby/setup-ruby@v1  
         with:
           ruby-version: '3.0' # Not needed with a .ruby-version file
-          bundler-cache: true # runs 'bundle install' and caches installed gems automatica
-      - run: |
+          bundler-cache: false # runs 'bundle install' and caches installed gems automatically
+      - name: Release cookbook
+        run: |
+          gem install stove
           mkdir -p ~/.chef
           echo ${{ secrets.SUPERMARKET_PEM }} | base64 --decode > ~/.chef/key.pem
-          bundle exec stove login --username ${{ secrets.SUPERMARKET_USER }} --key ~/.chef/key.pem
-          bundle exec stove --log-level debug --branch main
+          stove login --username ${{ secrets.SUPERMARKET_USER }} --key ~/.chef/key.pem
+          git status --porcelain
+          stove --log-level debug --branch main


### PR DESCRIPTION
bundler caused issues because it generates a vendor directory in the current repo which makes stove super unhappy.