### PR TITLE
Add .claude to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ bin/*
 .kitchen/
 .kitchen.local.yml
 
+# Claude Code
+.claude/
+
 # Chef
 Berksfile.lock
 .zero-knife.rb


### PR DESCRIPTION
## Summary
- Add `.claude/` directory to `.gitignore` to exclude Claude Code local settings from version control

## Test plan
- No functional changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)