### PR TITLE
Update Mondoo description and drop cnquery references

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 [![Cookbook Version](https://img.shields.io/cookbook/v/mondoo.svg)](https://supermarket.chef.io/cookbooks/mondoo)
 [![License](https://img.shields.io/badge/License-BUSL--1.1-green.svg)](https://spdx.org/licenses/BUSL-1.1.html)
 
-This cookbook installs Mondoo `cnquery` and `cnspec` on Linux servers for infrastructure security, compliance, and asset intelligence.
+This cookbook installs and configures Mondoo's `cnspec` on Linux servers and connects it to Mondoo Platform for continuous vulnerability management, security, and compliance.
 
 The `default` cookbook recipe:
 
 * Installs the signed `mondoo` package
-* Logs in `cnquery` and `cnspec` with Mondoo Platform
+* Logs in `cnspec` with Mondoo Platform
 * Enables the `cnspec` systemd service
 
 ## Requirements

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ name 'mondoo'
 maintainer 'Mondoo, Inc'
 maintainer_email 'hello@mondoo.com'
 license 'BUSL-1.1'
-description 'Installs and configures Mondoo package for infrastructure security, compliance, and asset intelligence'
+description "Installs and configures Mondoo's cnspec for continuous vulnerability management, security, and compliance"
 version '1.1.0'
 chef_version '>= 17'
 source_url 'https://github.com/mondoohq/chef-mondoo'


### PR DESCRIPTION
## Summary

Updates how the cookbook describes Mondoo in the README and `metadata.rb` to match Mondoo's current positioning on https://mondoo.com/.

- Lead with **continuous vulnerability management, security, and compliance** (Mondoo's current framing), replacing the older "infrastructure security, compliance, and asset intelligence" language.
- Remove all `cnquery` references — it's no longer a thing, and the recipe never invoked it anyway (`recipes/default.rb` only uses `cnspec`), so this also corrects an inaccuracy.
- Describe the cookbook as installing/configuring `cnspec` and connecting it to Mondoo Platform.

Docs-only change; recipes are unmodified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)