### PR TITLE
Overhaul README and fix doc/code drift

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -1,0 +1,2 @@
+ChefSpec
+yml

--- a/README.md
+++ b/README.md
@@ -1,15 +1,43 @@
 # Mondoo Package Chef Cookbook
 
 [![Cookbook Version](https://img.shields.io/cookbook/v/mondoo.svg)](https://supermarket.chef.io/cookbooks/mondoo)
+[![Unit Tests](https://github.com/mondoohq/chef-mondoo/actions/workflows/unit.yaml/badge.svg)](https://github.com/mondoohq/chef-mondoo/actions/workflows/unit.yaml)
 [![License](https://img.shields.io/badge/License-BUSL--1.1-green.svg)](https://spdx.org/licenses/BUSL-1.1.html)
 
-This cookbook installs and configures Mondoo's `cnspec` on Linux servers and connects it to Mondoo Platform for continuous vulnerability management, security, and compliance.
+This cookbook installs and configures Mondoo's [`cnspec`](https://github.com/mondoohq/cnspec) on Linux servers and connects it to [Mondoo Platform](https://mondoo.com/) for continuous vulnerability management, security, and compliance.
 
-The `default` cookbook recipe:
+## Usage
 
-* Installs the signed `mondoo` package
-* Logs in `cnspec` with Mondoo Platform
-* Enables the `cnspec` systemd service
+1. **Get a registration token.** In the [Mondoo Console](https://app.mondoo.com/), open the Space you want assets to report into and create a registration token under that Space's settings. See the [cnspec documentation](https://mondoo.com/docs/cnspec/) for more on how `cnspec` registers and scans.
+
+2. **Add the cookbook to your run list and set the token.** Depend on `mondoo` from your wrapper cookbook (`depends 'mondoo'` in `metadata.rb`) and set the registration token as an attribute. The minimum required attribute is `registration_token`:
+
+   ```ruby
+   # in a role, environment, Policyfile, or wrapper cookbook attributes
+   default['mondoo']['registration_token'] = 'YOUR_REGISTRATION_TOKEN'
+   ```
+
+   Then add the default recipe to your run list:
+
+   ```ruby
+   run_list 'recipe[mondoo::default]'
+   ```
+
+> [!CAUTION]
+> The registration token is a secret. Source it from an encrypted data bag, a node attribute set by your provisioning pipeline, or another secrets manager rather than committing it to version control.
+
+See the [`examples/`](examples) directory for a complete wrapper cookbook (including a `chef-run` walkthrough).
+
+## What this cookbook does
+
+The `default` recipe:
+
+* Adds the signed Mondoo package repository (APT on Debian/Ubuntu, YUM/DNF on RHEL-family, Zypper on SUSE) and installs the `mondoo` package
+* Creates the `/etc/opt/mondoo/` configuration directory
+* Registers the node with Mondoo Platform by running `cnspec login` with your registration token (and optional API proxy), writing credentials to `/etc/opt/mondoo/mondoo.yml`
+* Adds or removes the `api_proxy` setting in `mondoo.yml` based on the `api_proxy` attribute
+* Starts and enables the `cnspec.service` systemd service for scheduled scans
+* Stops and disables the deprecated `mondoo.service` if present
 
 ## Requirements
 
@@ -31,37 +59,83 @@ The `default` cookbook recipe:
 
 * [line cookbook](https://supermarket.chef.io/cookbooks/line)
 
+## Recipes
+
+| Recipe | Description |
+| ------ | ----------- |
+| `mondoo::default` | Entry point. Configures the repository, installs `cnspec`, registers the node, and enables the service. This is the only recipe you should add to a run list. |
+| `mondoo::deb` | Internal helper. Configures the APT repository and installs the package on Debian/Ubuntu. Included automatically by `default`. |
+| `mondoo::rpm` | Internal helper. Configures the YUM/Zypper repository and installs the package on RHEL-family and SUSE platforms. Included automatically by `default`. |
+
 ## Attributes
 
-| Name           | Default Value | Description                        |
-| -------------- | ------------- | -----------------------------------|
-| `default['mondoo']['registration_token']` | `change_me` | Mondoo Registration Token that is used to retrieve client credentials
-| `default['mondoo']['api_proxy']` | `` | Proxy server URL setting for communication with Mondoo Platform
+| Attribute | Default | Description |
+| --------- | ------- | ----------- |
+| `default['mondoo']['registration_token']` | `change_me` | Mondoo registration token used to retrieve client credentials. **Required** — override this. |
+| `default['mondoo']['api_proxy']` | `nil` | Proxy server URL for communication with Mondoo Platform (for example, `http://proxy.example.com:3128`). When set, it is written to `mondoo.yml`; when unset, any existing `api_proxy` line is removed. |
+| `default['mondoo']['deb']['repo']` | `https://releases.mondoo.com/debian/` | APT repository URL for Debian/Ubuntu. Override to use a local mirror. |
+| `default['mondoo']['deb']['gpgkey']` | `https://releases.mondoo.com/debian/pubkey.gpg` | GPG key URL used to verify the APT repository. |
+| `default['mondoo']['rpm']['repo']` | `https://releases.mondoo.com/rpm/$basearch/` | YUM/Zypper repository URL for RHEL-family and SUSE. Override to use a local mirror. |
+| `default['mondoo']['rpm']['gpgkey']` | `https://releases.mondoo.com/rpm/pubkey.gpg` | GPG key URL used to verify the RPM repository. |
+
+## Verify
+
+After a successful Chef run, confirm the node is registered and reporting:
+
+```bash
+# The service that runs scheduled scans should be active and enabled
+systemctl status cnspec.service
+
+# Confirm cnspec is registered with Mondoo Platform
+cnspec status
+
+# Credentials and configuration are written here
+cat /etc/opt/mondoo/mondoo.yml
+```
+
+The registered asset also appears in your Space in the [Mondoo Console](https://app.mondoo.com/).
+
+## Troubleshooting
+
+* **Registration fails / asset never appears.** Confirm the `registration_token` is valid and belongs to the intended Space. The token is consumed during `cnspec login`; once `/etc/opt/mondoo/mondoo.yml` exists, the login step is skipped on subsequent converges (it is guarded by `creates`). To re-register, remove `mondoo.yml` and run Chef again.
+* **Behind a proxy.** Set `default['mondoo']['api_proxy']` so both the `cnspec login` call and the persisted `mondoo.yml` use the proxy.
+* **Offline or mirrored repositories.** Override the `deb`/`rpm` `repo` and `gpgkey` attributes to point at your internal mirror.
 
 ## Examples
 
-See the `examples` directory for examples of using this cookbook.
+See the [`examples/`](examples) directory for a complete wrapper cookbook and a `chef-run` walkthrough.
 
 ## Testing
 
-Ensure Docker is installed and run:
+This repo uses [Test Kitchen](https://kitchen.ci/) for integration tests, [ChefSpec](https://github.com/chefspec/chefspec) for unit tests, and [Cookstyle](https://docs.chef.io/workstation/cookstyle/) for linting. All three run in CI.
 
 ```bash
+# Lint
+cookstyle .
+
+# Unit tests
+chef exec rspec
+
+# Integration tests (requires Docker)
 MONDOO_TOKEN=ey...Bp kitchen test
 ```
 
-(or add MONDOO_API_PROXY to the list of variables to test the setting/using of that variable)
+For integration tests, add `MONDOO_API_PROXY` to the variables to exercise the proxy setting. You can "enter" the resulting test environment by changing the `kitchen test` command to `kitchen login`. To speed up local testing, comment out unneeded entries in `kitchen.yml`.
 
-You can "enter" the resulting environment used for the test by changing the 'test' kitchen command to 'login'.
+The `Makefile` provides additional checks used in CI:
 
-You can reduce the number of environments tested (to speed up local testing) by commenting out unnecessary entries from kitchen.yml.
+```bash
+make test/spell-check       # spell check via act
+make license                # check copyright/license headers
+make license/headers/apply  # apply missing license headers
+```
 
 ## Release
 
-This repo includes a GitHub action "Supermarket Release", which you can manually trigger to perform a release. Before running this workflow make sure to:
+This repo includes a GitHub Action "Supermarket Release", which you can manually trigger to perform a release. Before running this workflow make sure to:
 
-- Update the metadata.rb file with the new version.
-- Update the CHANGELOG.md file to document the new release.
+- Update the `metadata.rb` file with the new version.
+- Update the `CHANGELOG.md` file to document the new release.
 
 ## Author
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -33,7 +33,7 @@ default_source :supermarket
 cookbook 'mondoo'
 cookbook 'run', path: './'
 
-default['mondoo']['registration_token'] = 'changeme'
+default['mondoo']['registration_token'] = 'change_me'
 EOF
 ```
 

--- a/examples/run/Policyfile.rb
+++ b/examples/run/Policyfile.rb
@@ -9,4 +9,4 @@ default_source :supermarket
 cookbook 'mondoo'
 cookbook 'run', path: './'
 
-default['mondoo']['registration_token'] = 'changeme'
+default['mondoo']['registration_token'] = 'change_me'

--- a/test/integration/default/default_test.rb
+++ b/test/integration/default/default_test.rb
@@ -7,10 +7,6 @@ describe package('mondoo') do
   it { should be_installed }
 end
 
-describe package('cnquery') do
-  it { should be_installed }
-end
-
 describe package('cnspec') do
   it { should be_installed }
 end


### PR DESCRIPTION
## Summary

A deep-dive documentation pass on the README, plus fixes for the doc/code drift it surfaced. Follows up on the Mondoo description update (#117).

### README — onboarding
- **New Usage section**: get a registration token, set `registration_token`, add `mondoo::default` to the run list, with a caution about handling the token as a secret.
- **New Verify section**: `systemctl status cnspec.service`, `cnspec status`, config at `/etc/opt/mondoo/mondoo.yml`.
- **New Troubleshooting section**: registration re-runs (the `creates` guard), proxy, and offline/mirrored repos.
- **Outbound links** to Mondoo Platform, `cnspec`, and the Console, plus a unit-test CI badge.

### README — reference accuracy
- **New Recipes table** clarifying `default` is the entry point and `deb`/`rpm` are internal helpers.
- **"What the cookbook does"** now matches `recipes/default.rb` — config dir creation, `cnspec login`, `api_proxy` handling, and disabling the deprecated `mondoo.service`.
- **Attributes table** now documents all six attributes, including the previously undocumented `deb`/`rpm` `repo` and `gpgkey` overrides (useful for mirrors).
- **Testing section** expanded to cover Cookstyle lint, ChefSpec unit tests, Test Kitchen, and the `Makefile` checks.

### Fixes for drift surfaced by the review
- Removed the stale `cnquery` package assertion from `test/integration/default/default_test.rb` so it matches the cnspec-only reality (continues the cnquery removal from #117).
- Aligned the example registration-token placeholder (`changeme` → `change_me`) with the attribute default.
- Added `ChefSpec` and `yml` to the check-spelling `expect.txt` for the new docs (verified the rest of the new vocabulary is already covered by the configured dictionaries).

All changes are docs/tests/config only — no recipe behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)