### PR TITLE
Add Test Kitchen integration CI (and fix cnspec service teardown it caught)

### DIFF
--- a/.github/workflows/kitchen.yaml
+++ b/.github/workflows/kitchen.yaml
@@ -1,0 +1,47 @@
+---
+name: Integration Testing
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: kitchen-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  kitchen:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    # cnspec login needs the MONDOO_TOKEN secret, which is not exposed to pull
+    # requests from forks. Skip (rather than fail) when the PR is from a fork;
+    # always run for workflow_dispatch and same-repo PRs.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    strategy:
+      fail-fast: false
+      matrix:
+        # One platform per package manager: apt, yum/dnf, and zypper.
+        # Values are dot-agnostic regexes matched against kitchen instance names.
+        platform:
+          - ubuntu-24
+          - rockylinux-9
+          - opensuse-leap-15
+    steps:
+      - name: Check out code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install Chef Workstation
+        run: curl -L https://omnitruck.chef.io/install.sh | sudo bash -s -- -P chef-workstation
+
+      - name: Test Kitchen
+        run: kitchen test "${PLATFORM}" --destroy=always
+        env:
+          PLATFORM: ${{ matrix.platform }}
+          CHEF_LICENSE: accept-no-persist
+          MONDOO_TOKEN: ${{ secrets.MONDOO_TOKEN }}

--- a/.github/workflows/kitchen.yaml
+++ b/.github/workflows/kitchen.yaml
@@ -36,11 +36,11 @@ jobs:
       - name: Check out code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Install Chef Workstation
-        run: curl -L https://omnitruck.chef.io/install.sh | sudo bash -s -- -P chef-workstation
+      - name: Install Cinc Workstation
+        uses: sous-chefs/install-workstation@c8303c13fb472d166ce0185d62a360b5fe782122 # v0.1.0
 
       - name: Test Kitchen
-        run: kitchen test "${PLATFORM}" --destroy=always
+        run: chef exec kitchen test "${PLATFORM}" --destroy=always
         env:
           PLATFORM: ${{ matrix.platform }}
           CHEF_LICENSE: accept-no-persist

--- a/.github/workflows/kitchen.yaml
+++ b/.github/workflows/kitchen.yaml
@@ -40,7 +40,10 @@ jobs:
         uses: sous-chefs/install-workstation@c8303c13fb472d166ce0185d62a360b5fe782122 # v0.1.0
 
       - name: Test Kitchen
-        run: chef exec kitchen test "${PLATFORM}" --destroy=always
+        # PLATFORM is a fixed, regex-safe value from the matrix allowlist above.
+        # Anchored to the "default-" suite prefix so it only matches the intended
+        # instance (e.g. default-ubuntu-2404) and nothing else.
+        run: chef exec kitchen test "default-${PLATFORM}" --destroy=always
         env:
           PLATFORM: ${{ matrix.platform }}
           CHEF_LICENSE: accept-no-persist

--- a/README.md
+++ b/README.md
@@ -36,8 +36,7 @@ The `default` recipe:
 * Creates the `/etc/opt/mondoo/` configuration directory
 * Registers the node with Mondoo Platform by running `cnspec login` with your registration token (and optional API proxy), writing credentials to `/etc/opt/mondoo/mondoo.yml`
 * Adds or removes the `api_proxy` setting in `mondoo.yml` based on the `api_proxy` attribute
-* Starts and enables the `cnspec.service` systemd service for scheduled scans
-* Stops and disables the deprecated `mondoo.service` if present
+* Starts and enables the `cnspec.service` systemd service (which runs `cnspec serve`)
 
 ## Requirements
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -47,12 +47,11 @@ else
 end
 
 # enable the service
+#
+# Note: cnspec.service declares `Alias=mondoo.service` in its [Install] section,
+# so mondoo.service is now the same unit as cnspec.service. We must NOT stop or
+# disable mondoo.service here — doing so would tear down the cnspec service we
+# just started/enabled.
 service 'cnspec.service' do
   action [:start, :enable]
-end
-
-# disable deprecated mondoo service
-service 'mondoo.service' do
-  action [:stop, :disable]
-  ignore_failure true
 end

--- a/spec/recipes/default_spec.rb
+++ b/spec/recipes/default_spec.rb
@@ -21,11 +21,6 @@ describe 'mondoo::default' do
     it 'marks the login as sensitive so the token is not logged' do
       expect(chef_run.find_resource(:execute, 'cnspec_login').sensitive).to be true
     end
-
-    it 'stops and disables the deprecated mondoo.service' do
-      expect(chef_run).to stop_service('mondoo.service')
-      expect(chef_run).to disable_service('mondoo.service')
-    end
   end
 
   context 'on Ubuntu' do

--- a/test/integration/default/default_test.rb
+++ b/test/integration/default/default_test.rb
@@ -35,10 +35,3 @@ describe service('cnspec.service') do
   it { should be_enabled }
   it { should be_running }
 end
-
-# The recipe stops and disables the deprecated mondoo.service; it must not be
-# left running or enabled (this also passes when the unit does not exist).
-describe service('mondoo.service') do
-  it { should_not be_enabled }
-  it { should_not be_running }
-end


### PR DESCRIPTION
## Summary

Adds a Test Kitchen + InSpec integration job that converges the cookbook in dokken containers on one platform per package manager (Ubuntu/apt, Rocky/yum, openSUSE/zypper), gated on the `MONDOO_TOKEN` secret and fork-safe.

**On its very first run, it caught a real recipe bug — now fixed in this PR.**

### The bug it caught

`cnspec.service` declares `Alias=mondoo.service` in its `[Install]` section, so `mondoo.service` is now the *same* systemd unit as `cnspec.service`. The recipe did:

```ruby
service 'cnspec.service' do action [:start, :enable] end   # bring cnspec up
service 'mondoo.service'  do action [:stop, :disable] end   # ...then tear the SAME unit down
```

So every converge started/enabled cnspec and then immediately stopped/disabled it via the alias. InSpec found `cnspec.service` installed but neither enabled nor running, identically on all three platforms.

**Fix:** removed the `mondoo.service` stop/disable block (the legacy standalone `mondoo.service` no longer exists — it's an alias of `cnspec.service` now), and dropped the now-incorrect unit/integration assertions and the README line describing it.

### Install hardening (from review)
- Installs Cinc Workstation via the SHA-pinned `sous-chefs/install-workstation` action instead of `curl | sudo bash`.
- Instance match anchored to the `default-` suite prefix; matrix values are a fixed regex-safe allowlist.

### Verification
- `bundle exec rspec` → 44 examples, 0 failures
- `cookstyle` clean
- Kitchen CI re-running to confirm cnspec.service now stays enabled + running

🤖 Generated with [Claude Code](https://claude.com/claude-code)