### PR TITLE
Converge Test Kitchen with Cinc instead of Chef Infra Client

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -5,14 +5,18 @@
 driver:
   name: dokken
   privileged: true  # because Docker and SystemD
-  chef_version: <%= ENV['CHEF_VERSION'] || 'current' %>
+  # Use Cinc Client (open-source Chef Infra Client build) instead of chef/chef.
+  # cincproject/cinc publishes 'latest' and major-version tags but no 'current'.
+  chef_version: <%= ENV['CHEF_VERSION'] || 'latest' %>
 
 transport:
   name: dokken
 
 provisioner:
   name: dokken
-  chef_license: accept-no-persist
+  # Converge with Cinc Client: pulls cincproject/cinc and runs cinc-client.
+  # Cinc skips Chef's license-acceptance prompt, so no chef_license is needed.
+  product_name: cinc
 
 platforms:
   - name: almalinux-8


### PR DESCRIPTION
## Summary

Switches the **in-container converge** from Chef Infra Client to Cinc Client. (The runner-side `kitchen`/`chef exec` tooling already runs on Cinc Workstation via the `sous-chefs/install-workstation` action.)

`kitchen-dokken` has first-class Cinc support: setting `product_name: cinc` on the provisioner makes it pull `cincproject/cinc` (instead of `chef/chef`), run `/opt/cinc/bin/cinc-client`, use a separate `cinc-<version>` volume, and skip the Chef license-acceptance prompt.

### Changes (kitchen.yml)
- `provisioner.product_name: cinc` — converge with Cinc Client.
- Removed `provisioner.chef_license` — Cinc doesn't prompt for license acceptance.
- `driver.chef_version` default `current` → `latest` — `cincproject/cinc` publishes `latest` and major-version tags (16–19) but **no `current` tag**, so the old default would fail the image pull. The `CHEF_VERSION` env override still works (e.g. `CHEF_VERSION=18`).

### Verification
- `kitchen.yml` ERB renders to valid YAML.
- The integration CI on this PR exercises the real converge with Cinc on all three matrix platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)