### PR TITLE
Slim chefignore to this cookbook's own non-published files

### DIFF
--- a/chefignore
+++ b/chefignore
@@ -10,7 +10,7 @@ spec/*
 test/*
 kitchen.yml
 .kitchen/*
-tmp/*
+tmp/**
 examples/*
 TESTING.MD
 

--- a/chefignore
+++ b/chefignore
@@ -10,6 +10,7 @@ spec/*
 test/*
 kitchen.yml*
 .kitchen/*
+tmp
 tmp/**
 examples/*
 TESTING.*

--- a/chefignore
+++ b/chefignore
@@ -8,11 +8,11 @@
 # Tests
 spec/*
 test/*
-kitchen.yml
+kitchen.yml*
 .kitchen/*
 tmp/**
 examples/*
-TESTING.MD
+TESTING.*
 
 # CI and development tooling
 .github/*

--- a/chefignore
+++ b/chefignore
@@ -1,115 +1,35 @@
-# Put files/directories that should be ignored in this file when uploading
-# to a Chef Infra Server or Supermarket.
-# Lines that start with '# ' are comments.
+# Files in this repository that are NOT part of the published cookbook and
+# should be excluded when uploading to a Chef Infra Server or Supermarket.
+#
+# The published cookbook is: attributes/, recipes/, metadata.rb, README.md,
+# CHANGELOG.md, and LICENSE. Everything listed below is tests, CI, or
+# development tooling.
 
-# OS generated files #
-######################
-.DS_Store
-ehthumbs.db
-Icon?
-nohup.out
-Thumbs.db
-.envrc
-
-# EDITORS #
-###########
-.#*
-.project
-.settings
-*_flymake
-*_flymake.*
-*.bak
-*.sw[a-z]
-*.tmproj
-*~
-\#*
-REVISION
-TAGS*
-tmtags
-.vscode
-.editorconfig
-
-## COMPILED ##
-##############
-*.class
-*.com
-*.dll
-*.exe
-*.o
-*.pyc
-*.so
-*/rdoc/
-a.out
-mkmf.log
-
-# Testing #
-###########
-.circleci/*
-.codeclimate.yml
-.delivery/*
-.foodcritic
-.kitchen*
-.mdlrc
-.overcommit.yml
-.rspec
-.rubocop.yml
-.travis.yml
-.watchr
-.yamllint
-azure-pipelines.yml
-Dangerfile
-examples/*
-features/*
-Guardfile
-kitchen.yml*
-mlc_config.json
-Procfile
-Rakefile
+# Tests
 spec/*
 test/*
+kitchen.yml
+.kitchen/*
+tmp/*
+examples/*
+TESTING.MD
 
-# SCM #
-#######
-.git
-.gitattributes
-.gitconfig
+# CI and development tooling
 .github/*
-.gitignore
-.gitkeep
-.gitmodules
-.svn
-*/.bzr/*
-*/.git
-*/.hg/*
-*/.svn/*
+.actrc
+.copywrite.hcl
+.ruby-version
+_typos.toml
+Makefile
+CONTRIBUTING.md
 
-# Berkshelf #
-#############
+# Dependency management
 Berksfile
 Berksfile.lock
-cookbooks/*
-tmp
-
-# Bundler #
-###########
-vendor/*
 Gemfile
 Gemfile.lock
 
-# Policyfile #
-##############
-Policyfile.rb
-Policyfile.lock.json
-
-# Documentation #
-#############
-CODE_OF_CONDUCT*
-CONTRIBUTING*
-documentation/*
-TESTING*
-UPGRADING*
-
-# Vagrant #
-###########
-.vagrant
-Vagrantfile
+# SCM and OS noise
+.git
+.gitignore
+.DS_Store


### PR DESCRIPTION
## Summary

Replaces the generic boilerplate `chefignore` (a ~115-line catch-all covering Vagrant, Policyfile, CircleCI, Travis, foodcritic, etc. — most of which this repo doesn't use) with a focused list of the test, CI, and development files that **actually exist here** and shouldn't be uploaded to Supermarket.

The published cookbook is just `attributes/`, `recipes/`, `metadata.rb`, `README.md`, `CHANGELOG.md`, and `LICENSE`. Everything excluded is tests (`spec/`, `test/`, `kitchen.yml`, `examples/`, `TESTING.MD`), CI/dev tooling (`.github/`, `.actrc`, `.copywrite.hcl`, `.ruby-version`, `_typos.toml`, `Makefile`, `CONTRIBUTING.md`), dependency files (`Berksfile`, `Gemfile`, and their locks), and SCM/OS noise.

Verified that after applying the new chefignore, the only files that remain for upload are the cookbook itself (plus `chefignore`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)