### PR TITLE
Add all testable supported platforms to Test Kitchen

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -25,6 +25,11 @@ platforms:
       image: dokken/almalinux-9
       pid_one_command: /usr/lib/systemd/systemd
 
+  - name: amazonlinux-2
+    driver:
+      image: dokken/amazonlinux-2
+      pid_one_command: /usr/lib/systemd/systemd
+
   - name: amazonlinux-2023
     driver:
       image: dokken/amazonlinux-2023
@@ -38,6 +43,11 @@ platforms:
   - name: debian-12
     driver:
       image: dokken/debian-12
+      pid_one_command: /bin/systemd
+
+  - name: debian-13
+    driver:
+      image: dokken/debian-13
       pid_one_command: /bin/systemd
 
   - name: fedora-latest


### PR DESCRIPTION
## Summary

Aligns the `kitchen.yml` platform list with `metadata.rb`'s `supports`, adding the two supported platforms that were missing and have public dokken images:

- **amazonlinux-2** (`supports 'amazon', '>= 2.0'` — only `amazonlinux-2023` was tested)
- **debian-13** (`supports 'debian', '>= 11.0'` — only 11 and 12 were tested)

### Not added (and why)
`metadata.rb` also declares `redhat >= 8` and `suse (SLES) >= 12`, but there are **no public dokken images** for them (`dokken/redhat-*` and `dokken/sles-*` 404 — both require vendor entitlements). They're covered in practice by the binary-compatible rebuilds already in the matrix: **AlmaLinux/Rocky** for RHEL and **openSUSE Leap** for SLES. Testing the real entitled images would need registration secrets and is out of scope here.

### Scope note
This expands the Test Kitchen platform list (14 platforms) for local/manual `kitchen test` runs. The integration **CI matrix** in `.github/workflows/kitchen.yaml` intentionally stays a representative subset (one per package manager) to keep PR runs fast; it can be widened later if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)