### PR TITLE
Fix debian-13 pid_one_command path

### DIFF
--- a/kitchen.yml
+++ b/kitchen.yml
@@ -52,7 +52,9 @@ platforms:
   - name: debian-13
     driver:
       image: dokken/debian-13
-      pid_one_command: /bin/systemd
+      # Debian 13 (trixie) ships systemd at /usr/lib/systemd/systemd, not
+      # /bin/systemd like debian-11/12 (matches the dokken-images CMD).
+      pid_one_command: /usr/lib/systemd/systemd
 
   - name: fedora-latest
     driver:


### PR DESCRIPTION
## Summary

Fixes the Debian 13 Test Kitchen failure:

```
Failed to complete #create action: ... exec: "/bin/systemd": stat /bin/systemd: no such file or directory
```

When debian-13 was added (#125) I copied debian-11/12's `pid_one_command: /bin/systemd`. But **Debian 13 (trixie) ships systemd at `/usr/lib/systemd/systemd`** — the [`dokken-images/debian-13` Dockerfile](https://github.com/test-kitchen/dokken-images/blob/main/debian-13/Dockerfile) uses `CMD [ "/usr/lib/systemd/systemd" ]` (vs debian-12's `CMD [ "/bin/systemd" ]`). So the container's init couldn't start.

The dokken-images image is correct — no upstream change is needed; only our `pid_one_command` was wrong.

## Notes
- **No upstream fix required.** The image is fine; this is purely our kitchen.yml config.
- **amazonlinux-2** (the other platform dropped from CI in #126) already has the correct `pid_one_command: /usr/lib/systemd/systemd`, so it was failing for a different reason — worth investigating separately before re-adding it.
- Once this merges, debian-13 can be re-added to the CI matrix (it was removed in #126 as a stopgap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)