### PR TITLE
Add Cinc-based Supermarket release workflow

### DIFF
--- a/.github/workflows/release-supermarket.yaml
+++ b/.github/workflows/release-supermarket.yaml
@@ -47,16 +47,15 @@ jobs:
 
       - name: Install Cinc CLI
         if: steps.check.outputs.release == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          tag=$(gh api repos/tas50/cinc-cli/releases/latest --jq .tag_name)
+          # Pinned cinc-cli release and its linux/amd64 checksum. Bump both
+          # together; the checksum is verified before the binary is run.
+          tag="v0.21.0"
+          sha256="8dd76b36a4c5cc532f524c27148b2f68d7cb4c4657ef6a146ebbad8be6636fa1"
           archive="cinc_${tag}_linux_amd64.tar.gz"
-          base="https://github.com/tas50/cinc-cli/releases/download/${tag}"
-          curl -fsSL -o "${archive}" "${base}/${archive}"
-          curl -fsSL -o SHA256SUMS "${base}/SHA256SUMS"
-          grep " ${archive}\$" SHA256SUMS | sha256sum -c -
+          curl -fsSL -o "${archive}" "https://github.com/tas50/cinc-cli/releases/download/${tag}/${archive}"
+          echo "${sha256}  ${archive}" | sha256sum -c -
           tar -xzf "${archive}"
           sudo install "cinc_${tag}_linux_amd64/cinc" /usr/local/bin/cinc
           cinc --version

--- a/.github/workflows/release-supermarket.yaml
+++ b/.github/workflows/release-supermarket.yaml
@@ -1,0 +1,82 @@
+---
+name: Supermarket Release
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - metadata.rb
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 2
+
+      # Only release when the metadata.rb version actually changed (a push that
+      # touches metadata.rb for other reasons — e.g. a description edit — should
+      # not publish). workflow_dispatch always releases the current version.
+      - name: Detect version bump
+        id: check
+        env:
+          EVENT: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          new=$(grep -E '^version' metadata.rb | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+          if [ "${EVENT}" = "workflow_dispatch" ]; then
+            echo "release=true" >> "$GITHUB_OUTPUT"
+            echo "Manual release of mondoo ${new}."
+            exit 0
+          fi
+          old=$(git show HEAD^:metadata.rb 2>/dev/null | grep -E '^version' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || true)
+          echo "previous=${old:-none} current=${new}"
+          if [ -n "${new}" ] && [ "${new}" != "${old}" ]; then
+            echo "release=true" >> "$GITHUB_OUTPUT"
+            echo "Version bumped to ${new}; releasing."
+          else
+            echo "release=false" >> "$GITHUB_OUTPUT"
+            echo "metadata.rb changed but version is unchanged (${new}); skipping release."
+          fi
+
+      - name: Install Cinc CLI
+        if: steps.check.outputs.release == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          tag=$(gh api repos/tas50/cinc-cli/releases/latest --jq .tag_name)
+          archive="cinc_${tag}_linux_amd64.tar.gz"
+          base="https://github.com/tas50/cinc-cli/releases/download/${tag}"
+          curl -fsSL -o "${archive}" "${base}/${archive}"
+          curl -fsSL -o SHA256SUMS "${base}/SHA256SUMS"
+          grep " ${archive}\$" SHA256SUMS | sha256sum -c -
+          tar -xzf "${archive}"
+          sudo install "cinc_${tag}_linux_amd64/cinc" /usr/local/bin/cinc
+          cinc --version
+
+      - name: Write Supermarket credentials
+        if: steps.check.outputs.release == 'true'
+        env:
+          SUPERMARKET_USER: ${{ secrets.SUPERMARKET_USER }}
+          SUPERMARKET_PEM: ${{ secrets.SUPERMARKET_PEM }}
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.cinc
+          printf '%s' "${SUPERMARKET_PEM}" | base64 --decode > ~/.cinc/supermarket.pem
+          chmod 600 ~/.cinc/supermarket.pem
+          {
+            echo "[default]"
+            echo "client_name = \"${SUPERMARKET_USER}\""
+            echo "client_key = \"${HOME}/.cinc/supermarket.pem\""
+          } > ~/.cinc/credentials
+
+      - name: Share cookbook on Supermarket
+        if: steps.check.outputs.release == 'true'
+        run: cinc supermarket share mondoo

--- a/.github/workflows/release-supermarket.yaml
+++ b/.github/workflows/release-supermarket.yaml
@@ -76,6 +76,7 @@ jobs:
             echo "client_name = \"${SUPERMARKET_USER}\""
             echo "client_key = \"${HOME}/.cinc/supermarket.pem\""
           } > ~/.cinc/credentials
+          chmod 600 ~/.cinc/credentials
 
       - name: Share cookbook on Supermarket
         if: steps.check.outputs.release == 'true'

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,38 @@
+# Development
+
+This document is for contributors and maintainers of the `mondoo` cookbook.
+
+## Testing
+
+This repo uses [Test Kitchen](https://kitchen.ci/) for integration tests, [ChefSpec](https://github.com/chefspec/chefspec) for unit tests, and [Cookstyle](https://docs.chef.io/workstation/cookstyle/) for linting. All three run in CI.
+
+```bash
+# Lint
+cookstyle .
+
+# Unit tests
+chef exec rspec
+
+# Integration tests (requires Docker)
+MONDOO_TOKEN=ey...Bp kitchen test
+```
+
+For integration tests, add `MONDOO_API_PROXY` to the variables to exercise the proxy setting. You can "enter" the resulting test environment by changing the `kitchen test` command to `kitchen login`. To speed up local testing, comment out unneeded entries in `kitchen.yml`. See [TESTING.MD](TESTING.MD) for more Test Kitchen commands.
+
+The `Makefile` provides additional checks used in CI:
+
+```bash
+make test/spell-check       # spell check via typos
+make license                # check copyright/license headers
+make license/headers/apply  # apply missing license headers
+```
+
+## Releasing
+
+Releases are published to [Chef Supermarket](https://supermarket.chef.io/cookbooks/mondoo) automatically by the **Supermarket Release** GitHub Action. To cut a release:
+
+1. Bump the `version` in `metadata.rb`.
+2. Update `CHANGELOG.md`.
+3. Merge to `main`.
+
+When `metadata.rb`'s version changes on `main`, the workflow installs the [Cinc CLI](https://github.com/tas50/cinc-cli) and runs `cinc supermarket share` using the `SUPERMARKET_USER` / `SUPERMARKET_PEM` repository secrets. A release can also be triggered manually from the Actions tab (`workflow_dispatch`).

--- a/README.md
+++ b/README.md
@@ -130,6 +130,16 @@ make license                # check copyright/license headers
 make license/headers/apply  # apply missing license headers
 ```
 
+## Releasing
+
+Releases are published to [Chef Supermarket](https://supermarket.chef.io/cookbooks/mondoo) automatically by the **Supermarket Release** GitHub Action. To cut a release:
+
+1. Bump the `version` in `metadata.rb`.
+2. Update `CHANGELOG.md`.
+3. Merge to `main`.
+
+When `metadata.rb`'s version changes on `main`, the workflow installs the [Cinc CLI](https://github.com/tas50/cinc-cli) and runs `cinc supermarket share` using the `SUPERMARKET_USER` / `SUPERMARKET_PEM` repository secrets. A release can also be triggered manually from the Actions tab (`workflow_dispatch`).
+
 ## Author
 
 Mondoo, Inc

--- a/README.md
+++ b/README.md
@@ -105,40 +105,9 @@ The registered asset also appears in your Space in the [Mondoo Platform](https:/
 
 See the [`examples/`](examples) directory for a complete wrapper cookbook and a `chef-run` walkthrough.
 
-## Testing
+## Development
 
-This repo uses [Test Kitchen](https://kitchen.ci/) for integration tests, [ChefSpec](https://github.com/chefspec/chefspec) for unit tests, and [Cookstyle](https://docs.chef.io/workstation/cookstyle/) for linting. All three run in CI.
-
-```bash
-# Lint
-cookstyle .
-
-# Unit tests
-chef exec rspec
-
-# Integration tests (requires Docker)
-MONDOO_TOKEN=ey...Bp kitchen test
-```
-
-For integration tests, add `MONDOO_API_PROXY` to the variables to exercise the proxy setting. You can "enter" the resulting test environment by changing the `kitchen test` command to `kitchen login`. To speed up local testing, comment out unneeded entries in `kitchen.yml`.
-
-The `Makefile` provides additional checks used in CI:
-
-```bash
-make test/spell-check       # spell check via typos
-make license                # check copyright/license headers
-make license/headers/apply  # apply missing license headers
-```
-
-## Releasing
-
-Releases are published to [Chef Supermarket](https://supermarket.chef.io/cookbooks/mondoo) automatically by the **Supermarket Release** GitHub Action. To cut a release:
-
-1. Bump the `version` in `metadata.rb`.
-2. Update `CHANGELOG.md`.
-3. Merge to `main`.
-
-When `metadata.rb`'s version changes on `main`, the workflow installs the [Cinc CLI](https://github.com/tas50/cinc-cli) and runs `cinc supermarket share` using the `SUPERMARKET_USER` / `SUPERMARKET_PEM` repository secrets. A release can also be triggered manually from the Actions tab (`workflow_dispatch`).
+Testing and release instructions for contributors are in [DEVELOPMENT.md](DEVELOPMENT.md).
 
 ## Author
 

--- a/chefignore
+++ b/chefignore
@@ -23,6 +23,7 @@ TESTING.*
 _typos.toml
 Makefile
 CONTRIBUTING.md
+DEVELOPMENT.md
 
 # Dependency management
 Berksfile


### PR DESCRIPTION
## Summary

Implements the deferred Supermarket release (the 3rd PR), rebuilt around the [Cinc CLI](https://github.com/tas50/cinc-cli) and the existing `SUPERMARKET_USER` / `SUPERMARKET_PEM` secrets.

### How it works
On a push to `main` that changes `metadata.rb`, the workflow:
1. **Detects a version bump** — compares the `version` in `metadata.rb` against the previous commit. A description-only edit (version unchanged) is skipped; only a real bump releases. `workflow_dispatch` always releases.
2. **Installs a pinned cinc-cli** — `v0.21.0`, downloaded and verified against a hardcoded, independently-computed `sha256` before installing (no `releases/latest`, no same-source `SHA256SUMS`).
3. **Writes `~/.cinc/credentials`** — a TOML profile with `client_name` = `SUPERMARKET_USER` and `client_key` = the base64-decoded `SUPERMARKET_PEM` (written `0600`).
4. **Shares the cookbook** — `cinc supermarket share mondoo`, run from the repo root. cinc-cli's `Locate` accepts the current directory as the `mondoo` cookbook (verified against the source), and the upload respects the slimmed `chefignore`.

### Cookbook resolution
I traced `cinc supermarket share` through the cinc-cli source: it calls `localcookbook.Locate(name, path)`, which checks the current directory (matching on `metadata.rb` name) before `./<name>`, and errors if the metadata name doesn't match. So `share mondoo` from the repo root works with no staging.

### Security
- Secrets are passed via `env:` and never interpolated into a shell command.
- The release binary is checksum-verified before execution.
- The job runs with `permissions: contents: read` (publishing is external, via Supermarket).

### Docs
The README is kept user-facing. Testing and release instructions live in a new **DEVELOPMENT.md** (excluded from Supermarket uploads via `chefignore`); the README carries a one-line pointer to it.

## Requirements
- `SUPERMARKET_USER` and `SUPERMARKET_PEM` (base64-encoded private key) repository secrets — the same ones the old stove workflow used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)