### PR TITLE
Release 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,15 @@
 
 This file is used to list changes made in each version of the mondoo cookbook.
 
-## 1.1.0 (May 18, 2026)
+## 1.2.0 (June 27, 2026)
+
+- Fix `cnspec` being stopped and disabled on every Chef run. `cnspec.service` declares `Alias=mondoo.service`, so the recipe's old "disable deprecated `mondoo.service`" step was tearing down the very service it had just enabled; `cnspec` now runs as a persistent service after each converge.
+- Mark the `cnspec login` execution as `sensitive` so the registration token is not written to Chef run output.
+- Remove CentOS from the supported platforms; CentOS Linux is end-of-life.
+- Refresh the cookbook description and drop references to `cnquery`; the cookbook installs and runs `cnspec`.
+- Run Test Kitchen integration tests in CI on Cinc across the supported platforms, switch spell-checking to `typos`, and automate Supermarket releases with the Cinc CLI.
+
+## 1.1.0 (June 27, 2026)
 
 - Change the cookbook license from Apache 2.0 to the Business Source License 1.1 (BUSL-1.1).
 - Drop end-of-life platforms and raise the minimum supported Chef Infra Client and Cookstyle versions.

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ maintainer 'Mondoo, Inc'
 maintainer_email 'hello@mondoo.com'
 license 'BUSL-1.1'
 description "Installs and configures Mondoo's cnspec for continuous vulnerability management, security, and compliance"
-version '1.1.0'
+version '1.2.0'
 chef_version '>= 17'
 source_url 'https://github.com/mondoohq/chef-mondoo'
 issues_url 'https://github.com/mondoohq/chef-mondoo/issues'


### PR DESCRIPTION
## Summary

Cuts the **1.2.0** release: bumps `metadata.rb` and adds the changelog entry. Also re-dates the **1.1.0** entry to **June 27, 2026** — the day it actually landed on Supermarket.

> ⚠️ Merging this PR changes the `metadata.rb` version on `main`, which triggers the **Supermarket Release** workflow and publishes `mondoo` 1.2.0 to Chef Supermarket automatically. Make sure the `SUPERMARKET_USER` / `SUPERMARKET_PEM` secrets are set.

## What's new in 1.2.0

- **Fix:** `cnspec` is no longer stopped and disabled on every Chef run. `cnspec.service` declares `Alias=mondoo.service`, so the recipe's old "disable deprecated `mondoo.service`" step was tearing down the very service it had just enabled. `cnspec` now runs as a persistent service after each converge.
- **Security:** the `cnspec login` step is marked `sensitive`, so the registration token isn't written to Chef run output.
- **Platforms:** CentOS removed from the supported list (CentOS Linux is end-of-life).
- **Docs:** refreshed the cookbook description and dropped `cnquery` references — the cookbook installs and runs `cnspec`.
- **Testing / release tooling:** Test Kitchen integration tests now run in CI on Cinc across the supported platforms, spell-checking moved to `typos`, and Supermarket releases are automated via the Cinc CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)