### PR TITLE
Fix release: use `cinc version` not `cinc --version`

### DIFF
--- a/.github/workflows/release-supermarket.yaml
+++ b/.github/workflows/release-supermarket.yaml
@@ -58,7 +58,7 @@ jobs:
           echo "${sha256}  ${archive}" | sha256sum -c -
           tar -xzf "${archive}"
           sudo install "cinc_${tag}_linux_amd64/cinc" /usr/local/bin/cinc
-          cinc --version
+          cinc version
 
       - name: Write Supermarket credentials
         if: steps.check.outputs.release == 'true'


### PR DESCRIPTION
## Summary

The 1.2.0 Supermarket release [failed](https://github.com/mondoohq/chef-mondoo/actions/runs/28311441634/job/83876890765) at the install smoke-test:

```
cinc_v0.21.0_linux_amd64.tar.gz: OK
Error: unknown flag: --version
```

`tas50/cinc-cli` exposes version info through a `version` **subcommand** (`cinc version`), not a `--version` flag. The download + checksum + install all succeeded; only the smoke-test line was wrong. Switched it to `cinc version`.

## After merge
The version-bump trigger won't re-fire (this PR doesn't change `metadata.rb`), so 1.2.0 still needs to be published. Run the **Supermarket Release** workflow manually (`workflow_dispatch`) once this is on `main` — it releases the current version (1.2.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)